### PR TITLE
uncommented tapGesture property and made it accessible externally

### DIFF
--- a/APMultiMenu/APMultiMenu.h
+++ b/APMultiMenu/APMultiMenu.h
@@ -65,6 +65,7 @@
 //PanGesture Variables
 @property (nonatomic, assign) BOOL panGestureEnabled;
 //@property (nonatomic, assign) BOOL swipeGestureEnabled;
+@property (nonatomic, assign) BOOL tapGestureEnabled;
 
 //Initializations
 - (instancetype)init;

--- a/APMultiMenu/APMultiMenu.m
+++ b/APMultiMenu/APMultiMenu.m
@@ -37,7 +37,7 @@
 @property (nonatomic) CALayer *shadowLayer;
 
 //Tap Gesture
-//@property (nonatomic) UITapGestureRecognizer *tapGesture;
+@property (nonatomic) UITapGestureRecognizer *tapGesture;
 //@property (nonatomic, assign) BOOL tapGestureEnabled;
 
 //Swipe Gesture
@@ -650,7 +650,7 @@
 
 #pragma mark - UITapGestureRecognizer
 
-/*- (void)setTapGestureEnabled:(BOOL)tapGestureEnabled {
+- (void)setTapGestureEnabled:(BOOL)tapGestureEnabled {
     if (_tapGestureEnabled == tapGestureEnabled)
         return;
     
@@ -689,7 +689,7 @@
     
     if (_rightMenuStatus == APMultiMenuStatusOpen)
         [self toggleRightMenuWithAnimation:YES];
-}*/
+}
 
 #pragma mark - UISwipeGestureRecognizer
 


### PR DESCRIPTION
In a project I'm working on the requirements are as follows:

1) when the menu appears, controls in the visible portion of the main screen must not be active
==> this I can already do by disabling user interactions on the main screen when the menu appears

2) when I tap outside the menu (aka in the visible portion of the main screen) the menu must be dismissed
==> this I can do with this pull request, which does nothing but uncomment already present (but commented out) functionality, and make it configurable from outside
